### PR TITLE
Fix tab height in repository pages

### DIFF
--- a/js/contentScript.js
+++ b/js/contentScript.js
@@ -47,14 +47,17 @@ function launchActivity() {
     nav = $('.pagehead-tabs-item').filter(function () {
       return regex.test($(this).text());
     });
+    activitiesTab = '<a id="activity-tab" class="pagehead-tabs-item ga-tabs-item">' +
+                    '<img src="' + iconUrl + '" class="octicon ga-icon-wrapper">' +
+                    'Activities' +
+                    '</a>';
   } else if (pageType === REPOSITORY_PAGE) {
     nav = $('.reponav').children('.reponav-item:first');
+    activitiesTab = '<a id="activity-tab" class="reponav-item ga-tabs-item">' +
+    '<img src="' + iconUrl + '" class="octicon ga-icon-wrapper">' +
+    'Activities' +
+    '</a>';
   }
-
-  activitiesTab = '<a id="activity-tab" class="pagehead-tabs-item ga-tabs-item">' +
-  '<img src="' + iconUrl + '" class="octicon ga-icon-wrapper">' +
-  'Activities' +
-  '</a>';
   nav.before(activitiesTab);
 
   // For recording the number of unsupported activities,

--- a/styles/activities.css
+++ b/styles/activities.css
@@ -2,8 +2,6 @@
   font-weight: bold;
 }
 
-
-
 .ga-tabs-item:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
fix #22

## Description

- Add different classes for organization pages and repository pages

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:
